### PR TITLE
chore: refresh repository intelligence model and docs

### DIFF
--- a/.claude/repository-model.yaml
+++ b/.claude/repository-model.yaml
@@ -1,0 +1,184 @@
+version: 1
+facts:
+  languages:
+    - id: lang-python
+      value: Python
+      evidence:
+        - main.py
+        - requirements.txt
+        - README.md
+  frameworks:
+    - id: fw-matplotlib
+      value: matplotlib
+      evidence:
+        - requirements.txt
+        - main.py
+    - id: fw-pillow
+      value: pillow
+      evidence:
+        - requirements.txt
+        - main.py
+    - id: fw-pandas
+      value: pandas
+      evidence:
+        - requirements.txt
+        - main.py
+    - id: fw-seaborn
+      value: seaborn
+      evidence:
+        - requirements.txt
+        - main.py
+  commands:
+    - id: cmd-install
+      name: install
+      value: pip install -r requirements.txt
+      evidence:
+        - README.md
+        - requirements.txt
+    - id: cmd-run
+      name: run
+      value: python main.py
+      evidence:
+        - README.md
+        - main.py
+  entry_points:
+    - id: entry-main
+      value: main.py
+      evidence:
+        - main.py
+        - README.md
+  components:
+    - id: comp-cron-visualizer
+      name: cron-visualizer
+      path: .
+      evidence:
+        - main.py
+        - README.md
+        - requirements.txt
+  dependencies:
+    - id: dep-pandas
+      name: pandas
+      type: external
+      evidence:
+        - requirements.txt
+    - id: dep-seaborn
+      name: seaborn
+      type: external
+      evidence:
+        - requirements.txt
+    - id: dep-matplotlib
+      name: matplotlib
+      type: external
+      evidence:
+        - requirements.txt
+    - id: dep-pillow
+      name: pillow
+      type: external
+      evidence:
+        - requirements.txt
+    - id: dep-numpy
+      name: numpy
+      type: external
+      evidence:
+        - requirements.txt
+  external_services: []
+  testing: []
+analysis:
+  purpose:
+    value: Interactive Python tool that visualizes cron job schedules as a clickable monthly calendar with pixel-level daily and week timeline PNG views (1 pixel = 1 minute).
+    confidence: high
+    evidence_refs:
+      - entry-main
+      - comp-cron-visualizer
+      - fw-matplotlib
+      - fw-pillow
+  architecture:
+    value: "main() supplies a pipe-separated cron string to generate_monthly_calendar, which parses jobs, builds a matplotlib interactive calendar with thumbnail timelines, and on click delegates to show_daily_view (1440px PIL timeline) or show_week_view (stacked days). Cron matching and human-readable descriptions live in check_cron_matches_date / describe_cron_schedule."
+    confidence: high
+    evidence_refs:
+      - entry-main
+      - comp-cron-visualizer
+      - fw-matplotlib
+      - fw-pillow
+      - fw-pandas
+  patterns:
+    - id: pat-dark-mode-constants
+      value: Shared RGB/HEX dark-mode color constants at module top drive matplotlib and PIL rendering consistently.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - fw-matplotlib
+        - fw-pillow
+    - id: pat-multi-job-pipe
+      value: Multiple cron expressions are combined in one string separated by | and expanded into per-job execution times.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - comp-cron-visualizer
+    - id: pat-1440-timeline
+      value: Daily timelines are fixed 1440-wide arrays where each pixel maps to one minute of the day.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - dep-numpy
+        - fw-pillow
+    - id: pat-headless-matplotlib
+      value: Matplotlib backend selects TkAgg when tkinter is available, otherwise Agg for headless hosts.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - fw-matplotlib
+  component_notes:
+    - ref: comp-cron-visualizer
+      purpose: Single-module cron schedule visualizer; all parsing, calendar UI, and PNG timeline rendering live in main.py.
+      confidence: high
+  service_notes: []
+  dangerous_areas:
+    - id: dang-pipe-split-mismatch
+      value: Job splitting is inconsistent between generate_monthly_calendar (split on ' | ') and check_cron_matches_date / describe_cron_schedule (split on '|').
+      reason: Documented examples use spaced pipes, but callers that omit spaces build a different jobs list than matching/description paths; maintainers changing only one splitter can desync calendar job objects from match logic.
+      confidence: medium
+      evidence_refs:
+        - entry-main
+    - id: dang-month-year-boundaries
+      value: Crossing month or year boundaries in week/calendar views is untested.
+      reason: README troubleshooting states spanning month or year boundaries is untested and may not work as expected.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - comp-cron-visualizer
+    - id: dang-no-automated-tests
+      value: No automated test suite or CI workflows exist for cron parsing or rendering.
+      reason: Changes to parse_cron_part / check_cron_matches_date can silently break schedule correctness with no regression signal.
+      confidence: high
+      evidence_refs:
+        - entry-main
+        - comp-cron-visualizer
+  questions:
+    - id: q-readme-cd-path
+      question: README Usage says `cd cronVisualizer` before `python main.py`, but the GitHub repo directory is cron-visualizer and the workspace has no cronVisualizer folder — which path should agents use?
+      area: documentation
+      priority: medium
+      evidence_refs:
+        - cmd-run
+        - entry-main
+    - id: q-seaborn-unused
+      question: seaborn is listed in requirements.txt and imported in main.py but never referenced after import — should it be removed or is usage planned?
+      area: dependencies
+      priority: medium
+      evidence_refs:
+        - dep-seaborn
+        - fw-seaborn
+        - entry-main
+    - id: q-committed-sample-pngs
+      question: Sample outputs cron_calendar_2.png and daily_timeline_2025-06-03.png are committed while .gitignore comments suggest generated images are optional — should generated PNGs stay in VCS?
+      area: repository-hygiene
+      priority: low
+      evidence_refs:
+        - comp-cron-visualizer
+    - id: q-stale-module-docstring
+      question: main.py module docstring still says "Hello World - Main Python File" / "simple hello world program" despite being a full visualizer — intentional leftover or should docs be updated?
+      area: documentation
+      priority: low
+      evidence_refs:
+        - entry-main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Cron Schedule Visualizer
+
+## Purpose
+
+Interactive Python tool that turns cron expressions into a clickable monthly calendar plus pixel-level daily and week timeline PNGs (1 pixel = 1 minute).
+
+## Project Snapshot
+
+- Tech: Python 3.7+, matplotlib, Pillow, pandas, numpy (seaborn listed but unused in `main.py`)
+- Type: single-module script repo (no packages/, no CI, no tests)
+- Entry: `main.py` → `main()` → `generate_monthly_calendar`
+- Layout: flat root; no subdirectory `AGENTS.md` files
+
+## Commands
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+Library use (from `README.md`):
+
+```python
+from main import generate_monthly_calendar
+generate_monthly_calendar("*/15 9-17 * * *", year=2025, month=6)
+```
+
+Edit the hardcoded `cron_string` in `main()` to change the demo schedule.
+
+## Conventions
+
+- Multi-job schedules: separate expressions with ` | ` (spaces around `|`). Prefer this form everywhere; `generate_monthly_calendar` splits on `' | '` while `check_cron_matches_date` / `describe_cron_schedule` split on `'|'`.
+- Dark-mode colors: module-level RGB/HEX constants at top of `main.py` (`EXECUTION_COLOR_*`, `DARK_BACKGROUND_*`, etc.) — reuse these; do not hardcode new palette values in render paths.
+- Daily timelines: 1440-wide arrays in `show_daily_view` / `show_week_view` (1 px = 1 minute).
+- Matplotlib backend: TkAgg if tkinter exists, else Agg (`main.py` import block) — keep that order before `pyplot` import.
+- Output PNGs land in CWD: `cron_calendar_N.png`, `daily_timeline_YYYY-MM-DD.png`, `week_view_YYYY-MM_weekX.png`.
+- Cross-platform open: `open_image_cross_platform` — Windows `os.startfile`, macOS `open`, Linux `xdg-open`.
+
+## Directory Map
+
+- `main.py` — all parsing, calendar UI, daily/week PNG rendering
+- `requirements.txt` — runtime deps
+- `README.md` — usage, cron syntax, troubleshooting
+- `.claude/repository-model.yaml` — structured repo intelligence model
+
+## Architecture
+
+1. `parse_cron_part` / `check_cron_matches_date` — expand cron fields; OR day-of-month vs day-of-week when both are non-`*`.
+2. `generate_monthly_calendar` — matplotlib interactive grid, thumbnails, click → `show_daily_view` or `show_week_view`.
+3. `describe_cron_schedule` / `describe_single_cron_job` — human-readable titles.
+
+## Gotchas
+
+- **Pipe splitter mismatch** in `main.py`: keep job separators consistent (`' | '` vs `'|'`).
+- **Month/year boundaries** untested (see `README.md` troubleshooting) — do not assume week views spanning months are correct.
+- **No automated tests or CI** — treat `parse_cron_part` / `check_cron_matches_date` changes as high-risk; verify manually with known cron strings.
+- Font fallback: PIL tries `arial.ttf`, then default (`show_daily_view` / `show_week_view`).
+- Module docstring at top of `main.py` still says "Hello World"; ignore it — `README.md` is authoritative.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First-time repository intelligence explore for `cron-visualizer`: added `.claude/repository-model.yaml`, root `AGENTS.md`, and a `CLAUDE.md` stub (`@AGENTS.md`).

## Model stats

- **Facts written:** 14 entries (1 language, 4 frameworks, 2 commands, 1 entry point, 1 component, 5 dependencies; empty `external_services` / `testing`)
- **Analysis written:** purpose, architecture, 4 patterns, 1 component note, 3 dangerous areas, 4 questions
- **IDs:** first-time explore, no prior model — **0 carried forward, all newly minted**

## Validation (Phase 2)

- Deterministic `validate-schema.js`: passed (no structural/id/ref/evidence errors on first clean run after model write)
- Semantic review change applied:
  - `dang-pipe-split-mismatch`: confidence `high` → `medium`; reason refined (runtime often still works via re-split in `check_cron_matches_date`, but splitter inconsistency remains a maintainability footgun)

## AGENTS.md

- Written: `AGENTS.md` (root only — flat single-module repo; no subdir AGENTS needed)
- Stub: `CLAUDE.md` → `@AGENTS.md`
- Independent review score: **9/10**

## Open questions (human follow-up)

Highest priority first:

1. **medium — `q-readme-cd-path`:** README says `cd cronVisualizer` before `python main.py`, but the repo/workspace has no `cronVisualizer` folder (repo is `cron-visualizer`). Which path should agents use?
2. **medium — `q-seaborn-unused`:** `seaborn` is in `requirements.txt` and imported in `main.py` but never referenced after import — remove or planned use?
3. **low — `q-committed-sample-pngs`:** Sample PNGs are committed while `.gitignore` comments treat generated images as optional — keep in VCS?
4. **low — `q-stale-module-docstring`:** `main.py` module docstring still says "Hello World" despite being a full visualizer — update or leave?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e206b1d-6679-43d4-8e04-ec170abe6ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e206b1d-6679-43d4-8e04-ec170abe6ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

